### PR TITLE
Implement loading PR reviews using Github API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 /.env
 node_modules
+coverage

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Application } from 'probot' // eslint-disable-line no-unused-vars
-import { PullRequestsCreateReviewParams, IssuesAddLabelsParams, PullRequestsListReviewsParams, 
-  PullRequestsListReviewsResponse, PullRequestsListReviewsResponseItem } from '@octokit/rest'
+import {
+  PullRequestsCreateReviewParams, IssuesAddLabelsParams, PullRequestsListReviewsParams, PullRequestsListReviewsResponse
+} from '@octokit/rest'
 
 const getConfig = require('probot-config')
 
@@ -23,11 +24,11 @@ export = (app: Application) => {
 
     var approvedReviewDismissed = false
     if (context.payload.review) {
-      let reviewParams = context.issue()
-      const reviews = await context.github.pullRequests.listReviews(reviewParams as PullRequestsListReviewsParams);
-      
-      let autoapprovalReviews = (reviews.data as PullRequestsListReviewsResponse)
-        .filter((item: PullRequestsListReviewsResponseItem) => item.user.login === "autoapproval[bot]")
+      const reviewParams = context.issue()
+      const reviews = await context.github.pullRequests.listReviews(reviewParams as PullRequestsListReviewsParams)
+
+      const autoapprovalReviews = (reviews.data as PullRequestsListReviewsResponse)
+        .filter(item => item.user.login === 'autoapproval[bot]')
 
       const reviewDismissed = context.payload.action === 'dismissed'
       approvedReviewDismissed = autoapprovalReviews.length > 0 && reviewDismissed

--- a/test/fixtures/pull_request_reviews.json
+++ b/test/fixtures/pull_request_reviews.json
@@ -1,0 +1,40 @@
+[
+    {
+      "id": 80,
+      "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+      "user": {
+        "login": "autoapproval[bot]",
+        "id": 1,
+        "node_id": "MDQ6VXNlcjE=",
+        "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/octocat",
+        "html_url": "https://github.com/octocat",
+        "followers_url": "https://api.github.com/users/octocat/followers",
+        "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+        "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+        "organizations_url": "https://api.github.com/users/octocat/orgs",
+        "repos_url": "https://api.github.com/users/octocat/repos",
+        "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/octocat/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "body": "Here is the body for the review.",
+      "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+      "state": "APPROVED",
+      "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+      "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+      "_links": {
+        "html": {
+          "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+        },
+        "pull_request": {
+          "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+        }
+      }
+    }
+  ]
+  

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -171,10 +171,15 @@ describe('Autoapproval bot', () => {
   test('Autoapproval review was dismissed, approve PR again', async (done) => {
     const payload = require('./fixtures/pull_request_review.dismissed.json')
     const config = btoa('from_owner:\n  - dkhmelenko\nrequired_labels: []\nblacklisted_labels: []\napply_labels:\n  - merge')
+    const reviews = require('./fixtures/pull_request_reviews.json')
 
     nock('https://api.github.com')
       .get('/repos/dkhmelenko/autoapproval/contents/.github/autoapproval.yml')
       .reply(200, { content: config })
+
+    nock('https://api.github.com')
+      .get('/repos/dkhmelenko/autoapproval/pulls/1/reviews')
+      .reply(200, reviews)
 
     nock('https://api.github.com')
       .post('/repos/dkhmelenko/autoapproval/pulls/1/reviews', (body: any) => {


### PR DESCRIPTION
In order to check existing reviews if `pull_request_review.dismissed` event is received, the app will load reviews using GitHub API and will check if there any review from autoapproval bot.